### PR TITLE
make continue text configurable

### DIFF
--- a/src/components/DatePicker.svelte
+++ b/src/components/DatePicker.svelte
@@ -22,6 +22,7 @@
   export let morning = 7
   export let night = 19
   export let minuteStep = 5
+  export let continueText = 'Continue'
 
   const dispatch = createEventDispatcher()
 
@@ -199,7 +200,7 @@
         />
         {/if}
       </div>
-      <Toolbar on:change on:close={() => popover.close()} />
+      <Toolbar continueText={continueText} on:change on:close={() => popover.close()} />
     </div>
   </Popover>
 </div>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -8,7 +8,7 @@
   import { getContext, createEventDispatcher } from 'svelte'
   import { contextKey } from './lib/context.js'
 
-  export let continueText;
+  export let continueText
   
   const dispatch = createEventDispatcher()
 

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,12 +1,14 @@
 <div class="toolbar">
   <button type="button" class="button" on:click|preventDefault={progress}>
-    Continue
+    {continueText}
   </button>
 </div>
 
 <script>
   import { getContext, createEventDispatcher } from 'svelte'
   import { contextKey } from './lib/context.js'
+
+  export let continueText;
   
   const dispatch = createEventDispatcher()
 


### PR DESCRIPTION
No issue created.
Improve localization.

Can i.e. be tested with:
```jsx
<DatePicker
                  format='ddd, DD MMM YYYY HH:mm'
                  selected={[ dayjs('2020-04-20T16:15:33.000Z').toDate(), dayjs('2020-05-20T05:23:12.000Z').toDate() ]}
                  range={true}
                  continueText="Test"
                  time={true} />
```

Non-breaking