### PR TITLE
Fixes: #11: Selection over multiple months with end date now possible

### DIFF
--- a/src/components/lib/calendar.js
+++ b/src/components/lib/calendar.js
@@ -47,7 +47,7 @@ function getMonths (config) {
   const months = []
   const dayPropsHandler = getDayPropsHandler(firstDay, lastDay, selectableCallback)
   let date = dayjs(firstDay)
-  while (date.isBefore(lastDay)) {
+  while (date.isSameOrBefore(lastDay)) {
     months.push(getCalendarPage(date, dayPropsHandler))
     date = date.add(1, 'month')
   }

--- a/src/components/lib/date-utils.js
+++ b/src/components/lib/date-utils.js
@@ -1,9 +1,11 @@
 import dayjs from 'dayjs/esm'
 import localeData from 'dayjs/plugin/localeData'
 import minMax from 'dayjs/plugin/minMax'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 
 dayjs.extend(localeData)
 dayjs.extend(minMax)
+dayjs.extend(isSameOrBefore)
 
 export {
   dayjs


### PR DESCRIPTION
Fixes #11, #12

Can be tested with:
```jsx
<DatePicker range={true} on:range-selected={(e) => selected = e.detail} end={new Date()}></DatePicker>
```

Everything else seems to still work fine.