### PR TITLE
Fix calendar jumping

### DIFF
--- a/src/components/view/date-view/Month.svelte
+++ b/src/components/view/date-view/Month.svelte
@@ -34,10 +34,18 @@
         on:chosen
       />
     {/each}
+    {#if $monthView.visibleMonth.weeks.length === 5}
+      <!-- if we have a short month, with only 5 weeks, save some space -->
+      <div class="week-placeholder"></div>
+    {/if}
   </div>
 </div>
 
 <style>
+  .week-placeholder {
+    height: 38px; /* 32px element size + 2*3px margin */
+  }
+
   .month-dates { 
     width: 100%;
     display: -ms-grid;


### PR DESCRIPTION
Fixes: #6 

Fixes the jumping of the calendar, if we only have 5 weeks to display.

I really, really don't know if this is the best way we can solve this, but it works and should not break anything. I had a look at booking.com, and they are also reserving space for the 6 month.

If you have a better idea, I'm open for it.