### PR TITLE
Remove wrong positioning for mobile devices

### DIFF
--- a/src/components/lib/positioning.js
+++ b/src/components/lib/positioning.js
@@ -4,9 +4,7 @@ const getTranslate = async (w, contentsWrapper, translateX, translateY) => {
   const dist = await getDistanceToEdges(contentsWrapper, translateX, translateY)
   let x
   let y
-  if (w < 480) {
-    y = dist.bottom
-  } else if (dist.top < 0) {
+  if (dist.top < 0) {
     y = Math.abs(dist.top)
   } else if (dist.bottom < 0) {
     y = dist.bottom


### PR DESCRIPTION
I found this weird check in the position of the datepicker.
Is there a special use case why it is there?
I could not find any behavior where this is usefull.
What where your thoughts when creating this?

Before:
![image](https://user-images.githubusercontent.com/30698007/106657019-c555c180-659b-11eb-92ac-ef353ca78829.png)

After:
![image](https://user-images.githubusercontent.com/30698007/106657362-37c6a180-659c-11eb-855c-bd774c30e8c8.png)
