### PR TITLE
Added width style properties for datepicker and button

### DIFF
--- a/src/calendar-style.js
+++ b/src/calendar-style.js
@@ -6,6 +6,7 @@ class CalendarStyle {
     this.buttonBackgroundColor = '#fff'
     this.buttonBorderColor = '#eee'
     this.buttonTextColor = '#333'
+    this.buttonWidth = '300px'
     this.highlightColor = '#f7901e'
     this.passiveHighlightColor = '#FCD9B1'
 
@@ -35,7 +36,9 @@ class CalendarStyle {
 
     this.monthYearTextColor = '#3d4548'
     this.legendTextColor = '#4a4a4a'
-
+    
+    this.datepickerWidth = 'auto'
+    
     Object.entries(overrides).forEach(([ prop, value ]) => {
       this[prop] = value
     })
@@ -46,6 +49,7 @@ class CalendarStyle {
       --button-background-color: ${this.buttonBackgroundColor};
       --button-border-color: ${this.buttonBorderColor};
       --button-text-color: ${this.buttonTextColor};
+      --button-width: ${this.buttonWidth};
       --highlight-color: ${this.highlightColor};
       --passive-highlight-color: ${this.passiveHighlightColor};
 
@@ -76,6 +80,7 @@ class CalendarStyle {
 
       --month-year-text-color: ${this.monthYearTextColor};
       --legend-text-color: ${this.legendTextColor};
+      --datepicker-width: ${this.datepickerWidth};
 
       ${this.style}
     `

--- a/src/calendar-style.js
+++ b/src/calendar-style.js
@@ -36,9 +36,9 @@ class CalendarStyle {
 
     this.monthYearTextColor = '#3d4548'
     this.legendTextColor = '#4a4a4a'
-    
+
     this.datepickerWidth = 'auto'
-    
+
     Object.entries(overrides).forEach(([ prop, value ]) => {
       this[prop] = value
     })

--- a/src/components/DatePicker.svelte
+++ b/src/components/DatePicker.svelte
@@ -124,6 +124,7 @@
     display: inline-block;
     text-align: center;
     overflow: visible;
+    width: var(--datepicker-width);
   }
 
   .calendar-button {
@@ -131,7 +132,7 @@
     border: 1px solid var(--button-border-color);
     display: block;
     text-align: center;
-    width: 300px;
+    width: var(--button-width);
     text-decoration: none;
     cursor: pointer;
     background: var(--button-background-color);


### PR DESCRIPTION
Added two width style properties for the `datepicker` and `calendar-button` class.

This is to allow changing the space the datepicker will consume.