### PR TITLE
Fix dayjs plugin imports

### DIFF
--- a/src/components/lib/date-utils.js
+++ b/src/components/lib/date-utils.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs/esm'
-import localeData from 'dayjs/plugin/localeData'
-import minMax from 'dayjs/plugin/minMax'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import localeData from 'dayjs/esm/plugin/localeData'
+import minMax from 'dayjs/esm/plugin/minMax'
+import isSameOrBefore from 'dayjs/esm/plugin/isSameOrBefore'
+import isSameOrAfter from 'dayjs/esm/plugin/isSameOrAfter'
 
 dayjs.extend(localeData)
 dayjs.extend(minMax)


### PR DESCRIPTION
Closes #38.

Currently, this config is still required for the user to use `svelte-datepicker` in SvelteKit:
```js
const config = {
  kit: {
    target: "#svelte",
    vite: {
      ssr: {
        noExternal: ["dayjs"],
      },
    },
  },
};
```
However, this solves the `Cannot read property '$i' of undefined` error that they currently get.

Making this work out of the box without user config will require `dayjs` to either convert their ESM files to .mjs or to include a `{"type":"module"}` `package.json` file inside the `esm` directory, which they currently do not have.