### PR TITLE
Use locale order when listing weekdays

### DIFF
--- a/src/components/view/date-view/Month.svelte
+++ b/src/components/view/date-view/Month.svelte
@@ -21,7 +21,7 @@
   <div class="month-dates">
     <div class="legend">
       <div class="month-week">
-        {#each dayjs.weekdaysShort() as day}
+        {#each dayjs.weekdaysShort(true) as day}
           <span>{day}</span>
         {/each}
       </div>


### PR DESCRIPTION
Hi, thanks for a great library!

As I was trying it out, i noticed what I think is a bug when changing the locale for dayjs before rendering the `Datepicker` component: if the week starts on a different day for the given locale (e.g. monday), the weekdays and dates will not match.

In my example, I was setting dayjs's locale to 'no' (norwegian) before rendering the datepicker. Names of months and weekdays are correctly set according to the given locale, but the weekdays and dates do not match since `dayjs.weekdaysShort()` is not called with the `localeOrder`-flag set to `true`. `dayjs.weekdaysShort(true)` will return a list of weekdays where the order matches the locale used (e.g. monday first).

I couldn't find any way to enforce `localOrder` in my own dayjs config at first glance, so this seemed like the only solution that would work for me. Sorry if I'm missing something obvious!

The `localeOrder` feature in dayjs: https://github.com/iamkun/dayjs/issues/936