### PR TITLE
Implement default range for Range Picker

### DIFF
--- a/src/components/DatePicker.svelte
+++ b/src/components/DatePicker.svelte
@@ -9,6 +9,7 @@
   import View from './view/View.svelte'
 
   export let range = false
+  export let defaultRange = [1, "month"]
   export let placeholder = 'Choose Date'
   export let format = 'DD / MM / YYYY'
   export let start = dayjs().subtract(1, 'year')
@@ -33,6 +34,7 @@
     start: dayjs(start),
     end: dayjs(end),
     isRangePicker: range,
+    defaultRange,
     isTimePicker: time,
     closeOnFocusLoss,
     format,
@@ -66,7 +68,7 @@
     highlighted.set($selectedStartDate)
     dispatch('open')
   }
-  
+
   function setRangeValue () {
     selected = [ $selectedStartDate, $selectedEndDate ]
     dispatch('range-selected', {

--- a/src/components/DatePicker.svelte
+++ b/src/components/DatePicker.svelte
@@ -9,7 +9,7 @@
   import View from './view/View.svelte'
 
   export let range = false
-  export let defaultRange = [1, "month"]
+  export let defaultRange = [ 1, 'month' ]
   export let placeholder = 'Choose Date'
   export let format = 'DD / MM / YYYY'
   export let start = dayjs().subtract(1, 'year')

--- a/src/components/lib/sanitization.js
+++ b/src/components/lib/sanitization.js
@@ -21,7 +21,7 @@ function sanitizeInitialValue (value, config) {
   if (config.isRangePicker) {
     const [ from, to ] = value || []
     isDateChosen = Boolean(from).valueOf() && Boolean(to).valueOf()
-    chosen = isDateChosen ? value.map(dayjs) : [ dayjs.max(dayjs(), config.start), dayjs.min(dayjs().add(1, 'month'), config.end) ]
+    chosen = isDateChosen ? value.map(dayjs) : [ dayjs.max(dayjs(), config.start), dayjs.min(dayjs().add(...config.defaultRange), config.end) ]
   } else {
     isDateChosen = Boolean(value).valueOf()
     chosen = [ isDateChosen ? dayjs(value) : dayjs.max(dayjs(), config.start) ]


### PR DESCRIPTION
Hello.

Thanks for your work on this library, it is one of the best datepickers out there for Svelte right now. However, in my use, I ran into a significant issue where the default date range for range picker is hard-coded to 1 month, rather than being configurable.

This PR exposes the default range as input props, so that this can be configurable. 

This also solves issue #43 

Usage:

```
<DatePicker range={true} defaultRange={[2, 'days']} />
// default is [1, 'month']
```